### PR TITLE
Allow use of ceph-rgw without installing

### DIFF
--- a/libraries/ceph.rb
+++ b/libraries/ceph.rb
@@ -45,6 +45,14 @@ module CephHelper
       end
     end
 
+    def self.is_install_ceph_radosgw?(node)
+      if self.is_ceph_radosgw?(node)
+        return node['eucalyptus']['ceph-keyrings'] && node['eucalyptus']['ceph-keyrings']['radosgw']
+      else
+        return false
+      end
+    end
+
     def self.make_ceph_config(node, ceph_user)
       if node['ceph'] != nil
         mons = node['ceph']['topology']['mons']

--- a/recipes/user-facing.rb
+++ b/recipes/user-facing.rb
@@ -28,10 +28,10 @@ yum_package "ceph-radosgw" do
   action :upgrade
   options node['eucalyptus']['yum-options']
   flush_cache [:before]
-  only_if { CephHelper::SetCephRbd.is_ceph_radosgw?(node) }
+  only_if { CephHelper::SetCephRbd.is_install_ceph_radosgw?(node) }
 end
 
-if CephHelper::SetCephRbd.is_ceph_radosgw?(node)
+if CephHelper::SetCephRbd.is_install_ceph_radosgw?(node)
   ceph_config = CephHelper::SetCephRbd.get_configurations(
   node["eucalyptus"]["topology"]["objectstorage"]["ceph-config"],
   node["eucalyptus"]["ceph-config"])
@@ -39,68 +39,68 @@ if CephHelper::SetCephRbd.is_ceph_radosgw?(node)
   ceph_radosgw = CephHelper::SetCephRbd.get_configurations(
   node['eucalyptus']["topology"]["objectstorage"]['ceph-radosgw'],
   node['eucalyptus']['ceph-radosgw'])
-end
 
-template "/etc/ceph/ceph.conf" do
-  source "ceph.conf.erb"
-  owner 'ceph'
-  group 'ceph'
-  mode '0644'
-  action :create
-  variables(
-    :cephConfig => ceph_config,
-    :cephRadosGW => ceph_radosgw
-  )
-  only_if { CephHelper::SetCephRbd.is_ceph_radosgw?(node) }
-end
-
-if CephHelper::SetCephRbd.is_ceph_radosgw?(node)
-  ceph_keyrings = CephHelper::SetCephRbd.get_configurations(
-  node['eucalyptus']["topology"]["objectstorage"]['ceph-keyrings'],
-  node['eucalyptus']['ceph-keyrings'])
-
-  %w{admin radosgw bootstrap-rgw}.each do |ceph_user_keyring|
-    if ceph_keyrings[ceph_user_keyring]
-      template "#{ceph_keyrings[ceph_user_keyring]["keyring"]}" do
-        source "client-keyring.erb"
-        owner 'ceph'
-        group 'ceph'
-        mode '0600'
-        variables(
-          :keyring => ceph_keyrings[ceph_user_keyring]
-        )
-        action :create
-      end
-    else
-      raise Exception.new("Unable to create keyring file for #{ceph_user_keyring}!!!")
-    end
+  template "/etc/ceph/ceph.conf" do
+    source "ceph.conf.erb"
+    owner 'ceph'
+    group 'ceph'
+    mode '0644'
+    action :create
+    variables(
+      :cephConfig => ceph_config,
+      :cephRadosGW => ceph_radosgw
+    )
+    only_if { CephHelper::SetCephRbd.is_ceph_radosgw?(node) }
   end
-end
 
-# TODO make sure when multiple UFS is present, ceph user created once
-ruby_block "Create New Ceph User" do
-  block do
-    if node['eucalyptus']['topology']['objectstorage']['access-key'] == nil ||
-      node['eucalyptus']['topology']['objectstorage']['secret-key'] == nil
-      if node['eucalyptus']['topology']['objectstorage']['ceph-radosgw']['username']
-        new_username = node['eucalyptus']['topology']['objectstorage']['ceph-radosgw']['username']
+  if CephHelper::SetCephRbd.is_ceph_radosgw?(node)
+    ceph_keyrings = CephHelper::SetCephRbd.get_configurations(
+    node['eucalyptus']["topology"]["objectstorage"]['ceph-keyrings'],
+    node['eucalyptus']['ceph-keyrings'])
+
+    %w{admin radosgw bootstrap-rgw}.each do |ceph_user_keyring|
+      if ceph_keyrings[ceph_user_keyring]
+        template "#{ceph_keyrings[ceph_user_keyring]["keyring"]}" do
+          source "client-keyring.erb"
+          owner 'ceph'
+          group 'ceph'
+          mode '0600'
+          variables(
+            :keyring => ceph_keyrings[ceph_user_keyring]
+          )
+          action :create
+        end
       else
-        raise Exception.new("'username' not found in node['eucalyptus']['topology']['objectstorage']['ceph-radosgw']")
+        raise Exception.new("Unable to create keyring file for #{ceph_user_keyring}!!!")
       end
-      Chef::Log.info "ACCESS_KEY and/or SECRET_KEY not found. Creating new user: #{new_username}"
-      cmd = "radosgw-admin user create --uid=#{new_username} --display-name=#{new_username}"
-      shell = Mixlib::ShellOut.new(cmd)
-      shell.run_command
-      if !shell.exitstatus
-        raise "#{cmd} failed: " + shell.stdout + ", " + shell.stderr
-      end
-      new_user = JSON.parse(shell.stdout)
-      node.set['eucalyptus']['topology']['objectstorage']['access-key'] = new_user['keys'][0]['access_key']
-      node.set['eucalyptus']['topology']['objectstorage']['secret-key'] = new_user['keys'][0]['secret_key']
-      node.save
     end
   end
-  only_if { CephHelper::SetCephRbd.is_ceph_radosgw?(node) }
+
+  # TODO make sure when multiple UFS is present, ceph user created once
+  ruby_block "Create New Ceph User" do
+    block do
+      if node['eucalyptus']['topology']['objectstorage']['access-key'] == nil ||
+        node['eucalyptus']['topology']['objectstorage']['secret-key'] == nil
+        if node['eucalyptus']['topology']['objectstorage']['ceph-radosgw']['username']
+          new_username = node['eucalyptus']['topology']['objectstorage']['ceph-radosgw']['username']
+        else
+          raise Exception.new("'username' not found in node['eucalyptus']['topology']['objectstorage']['ceph-radosgw']")
+        end
+        Chef::Log.info "ACCESS_KEY and/or SECRET_KEY not found. Creating new user: #{new_username}"
+        cmd = "radosgw-admin user create --uid=#{new_username} --display-name=#{new_username}"
+        shell = Mixlib::ShellOut.new(cmd)
+        shell.run_command
+        if !shell.exitstatus
+          raise "#{cmd} failed: " + shell.stdout + ", " + shell.stderr
+        end
+        new_user = JSON.parse(shell.stdout)
+        node.set['eucalyptus']['topology']['objectstorage']['access-key'] = new_user['keys'][0]['access_key']
+        node.set['eucalyptus']['topology']['objectstorage']['secret-key'] = new_user['keys'][0]['secret_key']
+        node.save
+      end
+    end
+    only_if { CephHelper::SetCephRbd.is_ceph_radosgw?(node) }
+  end
 end
 
 ruby_block "Sync keys for User Facing Services" do
@@ -121,5 +121,5 @@ service "ceph-radosgw@rgw.euca-osg" do
   supports :status => true, :start => true, :stop => true, :restart => true
   retries 3
   retry_delay 10
-  only_if { CephHelper::SetCephRbd.is_ceph_radosgw?(node) }
+  only_if { CephHelper::SetCephRbd.is_install_ceph_radosgw?(node) }
 end


### PR DESCRIPTION
Only install/configure ceph radosgw on user facing hosts when the related configuration is present. This allows use of an existing gateway.