### PR TITLE
Use existing network settings for bridge if not given

### DIFF
--- a/templates/default/ifcfg-eth.erb
+++ b/templates/default/ifcfg-eth.erb
@@ -2,3 +2,4 @@ DEVICE=<%= node["eucalyptus"]["network"]["bridged-nic"] %>
 TYPE=Ethernet
 BRIDGE=<%= node["eucalyptus"]["network"]["bridge-interface"] %>
 NOZEROCONF=true
+NM_CONTROLLED=no


### PR DESCRIPTION
Allow for the standard value "none" when detecting statically configured network interfaces.

When the environment does not specify any of IPADDR, NETMASK, or GATEWAY use the values that were present in the bridged nic. This allows use of static networking with more than one node controller.