### PR TITLE
Support edge network configuration without explicit clusters

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -284,9 +284,11 @@ template "create network.json for EDGE" do
   source "network-edge.json.erb"
   action :create
   variables(
-    :clusters => Chef::JSONCompat.to_json_pretty(node["eucalyptus"]["network"]["clusters"]),
     :instanceDnsServers => node["eucalyptus"]["network"]["InstanceDnsServers"],
-    :publicIps => node["eucalyptus"]["network"]["PublicIps"]
+    :publicIps => node["eucalyptus"]["network"]["PublicIps"],
+    :privateIps => node["eucalyptus"]["network"]["PrivateIps"],
+    :clusters => node["eucalyptus"]["network"]["clusters"] ? Chef::JSONCompat.to_json_pretty(node["eucalyptus"]["network"]["clusters"]) : nil,
+    :subnets => node["eucalyptus"]["network"]["subnets"] ? Chef::JSONCompat.to_json_pretty(node["eucalyptus"]["network"]["subnets"]) : nil
   )
   only_if { node['eucalyptus']['network']['mode'] == 'EDGE' }
 end

--- a/templates/default/network-edge.json.erb
+++ b/templates/default/network-edge.json.erb
@@ -1,14 +1,19 @@
 {
-  "Clusters": <%= @clusters %>,
+  "Mode": "EDGE"<% if @instanceDnsServers -%>,
   "InstanceDnsServers": [
   <% @instanceDnsServers.each_with_index do |value, index| -%>
     "<%= value %>"<%= "," unless @instanceDnsServers.size == index + 1 %>
-  <% end %>
-  ],
-  "Mode": "EDGE",
+  <% end %>]<% end %><% if @publicIps -%>,
   "PublicIps": [
   <% @publicIps.each_with_index do |value, index| -%>
     "<%= value %>"<%= "," unless @publicIps.size == index + 1 %>
+  <% end %>]<% end %><% if @privateIps -%>,
+  "PrivateIps": [
+  <% @privateIps.each_with_index do |value, index| -%>
+    "<%= value %>"<%= "," unless @privateIps.size == index + 1 %>
+  <% end %>]<% end %><% if @clusters -%>,
+  "Clusters": <%= @clusters %>
+  <% end %><% if @subnets -%>,
+  "Subnets": <%= @subnets %>
   <% end %>
-  ]
 }


### PR DESCRIPTION
Allow environments that do not specify clusters as part of the network information. When clusters are omitted a single subnet should be present and private ip ranges are specified along with the public ip ranges.