### PR TITLE
Node settings for cpu passthrough and libvirt policy kit usage

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -130,6 +130,8 @@ default["eucalyptus"]["nc"]["hypervisor"] = "kvm"
 default["eucalyptus"]["nc"]["max-cores"] = "0"
 default["eucalyptus"]["nc"]["instance-path"] = "/var/lib/eucalyptus/instances"
 default["eucalyptus"]["nc"]["ipset-maxsets"] = "2048"
+#default["eucalyptus"]["nc"]["libvirt-use-policy-kit"] = "0"
+#default["eucalyptus"]["nc"]["use-cpu-passthrough"] = "0"
 
 # Ceph Packages
 default['eucalyptus']['ceph-repo'] = "http://download.ceph.com/rpm-hammer/el7/x86_64/"

--- a/templates/default/eucalyptus.conf.erb
+++ b/templates/default/eucalyptus.conf.erb
@@ -22,6 +22,12 @@ NC_CACHE_SIZE=<%= node["eucalyptus"]["nc"]["cache-size"] %>
 HYPERVISOR="<%= node["eucalyptus"]["nc"]["hypervisor"] %>"
 MAX_CORES="<%= node["eucalyptus"]["nc"]["max-cores"] %>"
 INSTANCE_PATH="<%= node["eucalyptus"]["nc"]["instance-path"] %>"
+<% if node["eucalyptus"]["nc"]["use-cpu-passthrough"] -%>
+USE_CPU_PASSTHROUGH="<%= node["eucalyptus"]["nc"]["use-cpu-passthrough"] %>"
+<% end -%>
+<% if node["eucalyptus"]["nc"]["libvirt-use-policy-kit"] -%>
+LIBVIRT_USE_POLICY_KIT="<%= node["eucalyptus"]["nc"]["libvirt-use-policy-kit"] %>"
+<% end -%>
 USE_VIRTIO_ROOT="1"
 USE_VIRTIO_DISK="1"
 USE_VIRTIO_NET="1"


### PR DESCRIPTION
Support for configuration of cpu passthrough and libvirt policy kit usage in eucalyptus.conf.